### PR TITLE
Socket URI args and no binding

### DIFF
--- a/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
+++ b/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
@@ -27,6 +27,8 @@ private:
   std::unique_ptr<franka::Model> franka_model_; ///< model object of the robot
   bool connected_;
   bool shutdown_;
+  std::string state_uri_; ///< URI of the socket to connect to for publishing state messages
+  std::string command_uri_; ///< URI of the socket to connect to for receiving command messages
   zmq::context_t zmq_context_;
   zmq::socket_t zmq_publisher_;
   zmq::socket_t zmq_subscriber_;
@@ -54,7 +56,7 @@ public:
    * @brief Constructor for the FrankaLightWeightInterface class
    * @param robot_ip ip adress of the robot to control
    */
-  explicit FrankaLightWeightInterface(std::string robot_ip);
+  explicit FrankaLightWeightInterface(std::string robot_ip, std::string state_uri, std::string command_uri);
 
   /**
    * @brief Getter of the connected boolean attribute

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,9 @@ using namespace frankalwi;
 
 int main(int, char**) {
   std::string robot_ip = "172.16.0.2";
-  FrankaLightWeightInterface flwi(robot_ip);
+  std::string state_uri = "0.0.0.0:5550";
+  std::string command_uri = "0.0.0.0:5551";
+  FrankaLightWeightInterface flwi(robot_ip, state_uri, command_uri);
   flwi.init();
   flwi.run_controller();
   return 0;


### PR DESCRIPTION
* Connect to state publisher socket instead of binding

This allows a docker container to bind the port between the
host and the container without conflict

* Pass socket URI for state and command messages

In case the URI (IP:PORT) needs to be changed, this can
be edited in the main.cpp file, or in future
passed through config files / command-line args