### PR TITLE
Fix inconsistency between types of jacobian and mass matrix

### DIFF
--- a/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
+++ b/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
@@ -42,7 +42,6 @@ private:
   Eigen::Matrix<double, 7, 1> current_joint_velocities_;
   Eigen::Matrix<double, 7, 1> current_joint_torques_;
   Eigen::Matrix<double, 6, 7> current_jacobian_;
-  std::array<double, 49> current_mass_array_;
   Eigen::Matrix<double, 7, 7> current_mass_;
   Eigen::Matrix<double, 7, 1> command_joint_torques_;
   std::chrono::steady_clock::time_point last_command_;

--- a/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
+++ b/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
@@ -41,7 +41,7 @@ template<std::size_t DOF>
 using Jacobian = std::array<Joints<DOF>, 6>;
 
 template<std::size_t DOF>
-using Mass = std::array<float, DOF*DOF>;
+using Mass = std::array<Joints<DOF>, DOF>;
 
 
 // --- Message structures --- //

--- a/src/FrankaLightWeightInterface.cpp
+++ b/src/FrankaLightWeightInterface.cpp
@@ -83,9 +83,10 @@ void FrankaLightWeightInterface::publish_robot_state() {
 
     for (std::size_t dof = 0; dof < 6; ++dof) {
       this->zmq_state_msg_.jacobian[dof][joint] = this->current_jacobian_(dof, joint);
+      this->zmq_state_msg_.mass[dof][joint] = this->current_mass_(dof, joint);
     }
+    this->zmq_state_msg_.mass[6][joint] = this->current_mass_(6, joint);
   }
-  std::copy(this->current_mass_array_.begin(), this->current_mass_array_.end(), this->zmq_state_msg_.mass.begin());
 
   this->zmq_state_msg_.eePose.position.x = this->current_cartesian_position_.x();
   this->zmq_state_msg_.eePose.position.y = this->current_cartesian_position_.y();
@@ -129,8 +130,8 @@ void FrankaLightWeightInterface::read_robot_state(const franka::RobotState& robo
   std::array<double, 42> jacobian_array = this->franka_model_->zeroJacobian(franka::Frame::kEndEffector, robot_state);
   this->current_jacobian_ = Eigen::Map<const Eigen::Matrix<double, 6, 7> >(jacobian_array.data());
 
-  this->current_mass_array_ = this->franka_model_->mass(robot_state);
-  this->current_mass_ = Eigen::Map<const Eigen::Matrix<double, 7, 7> >(this->current_mass_array_.data());
+  std::array<double, 49> current_mass_array = this->franka_model_->mass(robot_state);
+  this->current_mass_ = Eigen::Map<const Eigen::Matrix<double, 7, 7> >(current_mass_array.data());
 
   // get the twist from jacobian and current joint velocities
   this->current_cartesian_twist_ = this->current_jacobian_ * this->current_joint_velocities_;


### PR DESCRIPTION
There was inconsistency between the types of jacobian and mass matrices in the franka_lwi_communication_protocol header. This is now resolved.

The 'for' loops in FrankaLightWeightInterface.cpp are still not very nice, a map between Eigen and std would be preferred in the future. This is still marked as a TODO in there.