### PR TITLE
Add inline methods to convert Vec3D and Quaternion to std arrays

### DIFF
--- a/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
+++ b/include/franka_lightweight_interface/franka_lwi_communication_protocol.h
@@ -81,6 +81,14 @@ struct CommandMessage {
   Joints<DOF> jointTorque;
 };
 
+// --- Conversion helpers --- //
+inline std::array<datatype, 3> vec3DToArray(const Vec3D& vec3D) {
+  return std::array<datatype, 3>({vec3D.x, vec3D.y, vec3D.z});
+}
+
+inline std::array<datatype, 4> quaternionToArray(const Quaternion& quaternion) {
+  return std::array<datatype, 4>({quaternion.w, quaternion.x, quaternion.y, quaternion.z});
+}
 
 // --- Communication helpers --- //
 


### PR DESCRIPTION
Easy and useful.

Just realized that 'convert' is maybe not the correct term