### PR TITLE
Parse command line argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,10 +8,8 @@ int main(int argc, char** argv) {
   std::string robot_ip = "172.16.0.2";
   std::string state_uri = "0.0.0.0:1601";
   std::string command_uri = "0.0.0.0:1602";
-  if (argc == 2) {
-    if (atof(argv[1]) == 16) {
-      break;
-    } else if (atof(argv[1]) == 17) {
+  if (argc == 2 && atof(argv[1]) != 16) {
+    if (atof(argv[1]) == 17) {
       robot_ip = "172.17.0.2";
       state_uri = "0.0.0.0:1701";
       command_uri = "0.0.0.0:1702";


### PR DESCRIPTION
So we need to address the problem of the hardcoded robot IP and port numbers.
I propose to give the two frankas the ID 16 and 17 because thats what distinguishes their IP (172.16.0.1 and 172.17.0.1). The first two numbers in the URIs then correspond to that ID, the second two are '01' and '02' for state and command, respectively. 
I don't think that we need to fully parse robot_id and port numbers from the command line because we only have two robots for now anyway and these numbers need to be in so many places that I think it's fine to have them fixed here.
If you are fine with this, I'd change the README and I would also make sure that I put tags on the robots with their IP so that everybody can see if its the 16 or 17.

I also don't mind doing this another way if you prefer, but we need to do it soon :smile:

(@buschbapti can only tag one reviewer)