### PR TITLE
Add joint velocity controller

### DIFF
--- a/source/franka_lightweight_interface/CMakeLists.txt
+++ b/source/franka_lightweight_interface/CMakeLists.txt
@@ -39,3 +39,6 @@ install(TARGETS ${PROJECT_NAME}
 
 add_executable(example_joint_position_controller examples/joint_position_controller.cpp)
 target_link_libraries(example_joint_position_controller clproto cppzmq state_representation)
+
+add_executable(example_joint_velocity_controller examples/joint_velocity_controller.cpp)
+target_link_libraries(example_joint_velocity_controller clproto cppzmq state_representation)

--- a/source/franka_lightweight_interface/examples/joint_position_controller.cpp
+++ b/source/franka_lightweight_interface/examples/joint_position_controller.cpp
@@ -4,16 +4,16 @@
 int main(int argc, char** argv) {
   std::string state_uri = "*:1601";
   std::string command_uri = "*:1602";
-  if (argc == 2 && atof(argv[1]) != 16) {
+  if (argc == 2) {
     if (atof(argv[1]) == 17) {
       state_uri = "*:1701";
       command_uri = "*:1702";
-    } else {
+    } else if (atof(argv[1]) != 16) {
       std::cerr << "This robot is unknown, choose either '16' (default) or '17'." << std::endl;
       return 1;
     }
   } else {
-    std::cerr << "Please provide at one argument to choose which robot to connect to ('16' or '17')." << std::endl;
+    std::cerr << "Please provide at most one argument to choose which robot to connect to ('16' or '17')." << std::endl;
     return 1;
   }
 

--- a/source/franka_lightweight_interface/examples/joint_velocity_controller.cpp
+++ b/source/franka_lightweight_interface/examples/joint_velocity_controller.cpp
@@ -1,0 +1,47 @@
+#include "network_interfaces/control_type.h"
+#include "network_interfaces/zmq/network.h"
+
+int main(int argc, char** argv) {
+  std::string state_uri = "*:1601";
+  std::string command_uri = "*:1602";
+  if (argc == 2) {
+    if (atof(argv[1]) == 17) {
+      state_uri = "*:1701";
+      command_uri = "*:1702";
+    } else if (atof(argv[1]) != 16) {
+      std::cerr << "This robot is unknown, choose either '16' (default) or '17'." << std::endl;
+      return 1;
+    }
+  } else {
+    std::cerr << "Please provide at most one argument to choose which robot to connect to ('16' or '17')." << std::endl;
+    return 1;
+  }
+
+  double gain = 0.5;
+
+  ::zmq::context_t context(1);
+  ::zmq::socket_t subscriber, publisher;
+  network_interfaces::zmq::configure_sockets(context, subscriber, state_uri, publisher, command_uri, true, true);
+
+  network_interfaces::zmq::StateMessage state;
+  network_interfaces::zmq::CommandMessage command;
+
+  command.control_type = std::vector<int>{static_cast<int>(network_interfaces::control_type_t::VELOCITY)};
+  command.joint_state = state_representation::JointState::Zero("franka", 7);
+
+  state_representation::JointPositions target;
+  while (context.handle() != nullptr) {
+    if (network_interfaces::zmq::receive(state, subscriber)) {
+      if (target.is_empty()) {
+        target = state.joint_state;
+        command.joint_state = state.joint_state;
+        command.joint_state.set_zero();
+      }
+
+      auto velocities = gain * (target.get_positions() - state.joint_state.get_positions());
+      command.joint_state.set_velocities(velocities);
+
+      network_interfaces::zmq::send(command, publisher);
+    }
+  }
+}

--- a/source/franka_lightweight_interface/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
+++ b/source/franka_lightweight_interface/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
@@ -47,6 +47,7 @@ private:
   network_interfaces::zmq::CommandMessage command_;
   network_interfaces::control_type_t control_type_;
   Eigen::ArrayXd damping_gains_;
+  std::array<double, 7> impedance_values_;
   CollisionBehaviour collision_behaviour_;
   std::chrono::steady_clock::time_point last_command_;
   std::chrono::milliseconds command_timeout_ = std::chrono::milliseconds(500);
@@ -92,6 +93,18 @@ public:
    * @param[in] damping_gains The desired array of damping gains per joint.
    */
   void set_damping_gains(const std::array<double, 7>& damping_gains);
+
+  /**
+   * @brief Set the joint impedance.
+   * @param[in] impedance_values The desired array of impedance values per joint.
+   */
+  void set_impedance(const Eigen::Array<double, 7, 1>& impedance_values);
+
+  /**
+   * @brief Set the joint impedance.
+   * @param[in] impedance_values The desired array of impedance values per joint.
+   */
+  void set_impedance(const std::array<double, 7>& impedance_values);
 
   /**
    * @brief Set the collision behaviour.
@@ -185,6 +198,12 @@ public:
    * @brief Read and publish the robot state while no control commands are received
    */
   void run_state_publisher();
+
+  /**
+   * @brief Run the joint velocities controller
+   * that reads commands from the joint velocities subscription
+   */
+  void run_joint_velocities_controller();
 
   /**
    * @brief Run the joint torques controller

--- a/source/franka_lightweight_interface/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
+++ b/source/franka_lightweight_interface/include/franka_lightweight_interface/FrankaLightWeightInterface.hpp
@@ -46,8 +46,8 @@ private:
   network_interfaces::zmq::StateMessage state_;
   network_interfaces::zmq::CommandMessage command_;
   network_interfaces::control_type_t control_type_;
-  Eigen::ArrayXd damping_gains_;
-  std::array<double, 7> impedance_values_;
+  Eigen::ArrayXd joint_damping_gains_;
+  std::array<double, 7> joint_impedance_values_;
   CollisionBehaviour collision_behaviour_;
   std::chrono::steady_clock::time_point last_command_;
   std::chrono::milliseconds command_timeout_ = std::chrono::milliseconds(500);
@@ -84,27 +84,27 @@ public:
 
   /**
    * @brief Set the joint damping gains.
-   * @param[in] damping_gains The desired array of damping gains per joint.
+   * @param[in] joint_damping_gains The desired array of damping gains per joint.
    */
-  void set_damping_gains(const Eigen::Array<double, 7, 1>& damping_gains);
+  void set_joint_damping(const Eigen::Array<double, 7, 1>& joint_damping_gains);
 
   /**
    * @brief Set the joint damping gains.
-   * @param[in] damping_gains The desired array of damping gains per joint.
+   * @param[in] joint_damping_gains The desired array of damping gains per joint.
    */
-  void set_damping_gains(const std::array<double, 7>& damping_gains);
+  void set_joint_damping(const std::array<double, 7>& joint_damping_gains);
 
   /**
    * @brief Set the joint impedance.
-   * @param[in] impedance_values The desired array of impedance values per joint.
+   * @param[in] joint_impedance_values The desired array of impedance values per joint.
    */
-  void set_impedance(const Eigen::Array<double, 7, 1>& impedance_values);
+  void set_joint_impedance(const Eigen::Array<double, 7, 1>& joint_impedance_values);
 
   /**
    * @brief Set the joint impedance.
-   * @param[in] impedance_values The desired array of impedance values per joint.
+   * @param[in] joint_impedance_values The desired array of impedance values per joint.
    */
-  void set_impedance(const std::array<double, 7>& impedance_values);
+  void set_joint_impedance(const std::array<double, 7>& joint_impedance_values);
 
   /**
    * @brief Set the collision behaviour.

--- a/source/franka_lightweight_interface/src/FrankaLightWeightInterface.cpp
+++ b/source/franka_lightweight_interface/src/FrankaLightWeightInterface.cpp
@@ -20,6 +20,10 @@ static Eigen::Array<double, 7, 1> default_damping_gains() {
   return gains;
 }
 
+static std::array<double, 7> default_impedance_values() {
+  return {3000, 3000, 3000, 2500, 2500, 2000, 2000};
+}
+
 FrankaLightWeightInterface::FrankaLightWeightInterface(
     std::string robot_ip, std::string state_uri, std::string command_uri, std::string prefix
 ) :
@@ -32,6 +36,7 @@ FrankaLightWeightInterface::FrankaLightWeightInterface(
     zmq_context_(1),
     control_type_(network_interfaces::control_type_t::UNDEFINED),
     damping_gains_(default_damping_gains()),
+    impedance_values_(default_impedance_values()),
     collision_behaviour_(default_collision_behaviour()) {
 }
 
@@ -80,6 +85,18 @@ void FrankaLightWeightInterface::set_damping_gains(const Eigen::Array<double, 7,
 
 void FrankaLightWeightInterface::set_damping_gains(const std::array<double, 7>& damping_gains) {
   this->set_damping_gains(Eigen::ArrayXd::Map(damping_gains.data(), 7));
+}
+
+void FrankaLightWeightInterface::set_impedance(const Eigen::Array<double, 7, 1>& impedance_values) {
+  std::array<double, 7> values{};
+  for (std::size_t i = 0; i < 7; ++i) {
+    values.at(i) = impedance_values(i);
+  }
+  this->set_impedance(values);
+}
+
+void FrankaLightWeightInterface::set_impedance(const std::array<double, 7>& impedance_values) {
+  this->impedance_values_ = impedance_values;
 }
 
 void FrankaLightWeightInterface::set_collision_behaviour(

--- a/source/franka_lightweight_interface/src/FrankaLightWeightInterface.cpp
+++ b/source/franka_lightweight_interface/src/FrankaLightWeightInterface.cpp
@@ -21,7 +21,7 @@ static Eigen::Array<double, 7, 1> default_damping_gains() {
 }
 
 static std::array<double, 7> default_impedance_values() {
-  return {3000, 3000, 3000, 2500, 2500, 2000, 2000};
+  return {2000, 2000, 2000, 1500, 1500, 1000, 1000};
 }
 
 FrankaLightWeightInterface::FrankaLightWeightInterface(
@@ -246,7 +246,7 @@ void FrankaLightWeightInterface::run_joint_velocities_controller() {
         [this](
             const franka::RobotState& robot_state, franka::Duration
         ) -> franka::JointVelocities {
-          // check the local socket for a torque command
+          // check the local socket for a velocity command
           this->poll_external_command();
 
           if (this->control_type_ != network_interfaces::control_type_t::VELOCITY) {

--- a/source/franka_lightweight_interface/src/main.cpp
+++ b/source/franka_lightweight_interface/src/main.cpp
@@ -19,11 +19,11 @@ static void set_joint_damping(const std::string& level, FrankaLightWeightInterfa
 static void set_joint_impedance(const std::string& level, FrankaLightWeightInterface& flwi) {
   // TODO find three different levels
   if (level == "low") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{400, 400, 400, 300, 300, 200, 200});
   } else if (level == "medium") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{2000, 2000, 2000, 1500, 1500, 1000, 1000});
   } else if (level == "high") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{4000, 4000, 4000, 3000, 3000, 2000, 2000});
   }
 }
 

--- a/source/franka_lightweight_interface/src/main.cpp
+++ b/source/franka_lightweight_interface/src/main.cpp
@@ -16,6 +16,17 @@ static void set_joint_damping(const std::string& level, FrankaLightWeightInterfa
   }
 }
 
+static void set_joint_impedance(const std::string& level, FrankaLightWeightInterface& flwi) {
+  // TODO find three different levels
+  if (level == "low") {
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+  } else if (level == "medium") {
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+  } else if (level == "high") {
+    flwi.set_impedance(Eigen::Array<double, 7, 1>{3000, 3000, 3000, 2500, 2500, 2000, 2000});
+  }
+}
+
 static void set_collision_behaviour(const std::string& level, FrankaLightWeightInterface& flwi) {
   if (level == "low") {
     flwi.set_collision_behaviour(
@@ -103,6 +114,18 @@ int main(int argc, char** argv) {
     }
     std::cout << "Using collision sensitivity level " << collision_sensitivity << std::endl;
     set_collision_behaviour(collision_sensitivity, flwi);
+  }
+
+  option = parse_option(argv, argv + argc, "--joint-impedance");
+  if (option) {
+    std::string joint_impedance = std::string(option);
+    if (joint_impedance != "low" && joint_impedance != "medium" && joint_impedance != "high") {
+      std::cerr << "Provide one of (low, medium, high) for option --joint-impedance" << std::endl << help_message
+                << std::endl;
+      return 1;
+    }
+    std::cout << "Using joint impedance level " << joint_impedance << std::endl;
+    set_joint_impedance(joint_impedance, flwi);
   }
 
   flwi.init();

--- a/source/franka_lightweight_interface/src/main.cpp
+++ b/source/franka_lightweight_interface/src/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char** argv) {
 
   FrankaLightWeightInterface flwi(robot_ip, state_uri, command_uri, prefix);
 
+  int provided_options = 0;
   char* option = parse_option(argv, argv + argc, "--joint-damping");
   if (option) {
     std::string joint_damping = std::string(option);
@@ -102,6 +103,7 @@ int main(int argc, char** argv) {
     }
     std::cout << "Using joint damping level " << joint_damping << std::endl;
     set_joint_damping(joint_damping, flwi);
+    ++provided_options;
   }
 
   option = parse_option(argv, argv + argc, "--sensitivity");
@@ -114,6 +116,7 @@ int main(int argc, char** argv) {
     }
     std::cout << "Using collision sensitivity level " << collision_sensitivity << std::endl;
     set_collision_behaviour(collision_sensitivity, flwi);
+    ++provided_options;
   }
 
   option = parse_option(argv, argv + argc, "--joint-impedance");
@@ -126,6 +129,12 @@ int main(int argc, char** argv) {
     }
     std::cout << "Using joint impedance level " << joint_impedance << std::endl;
     set_joint_impedance(joint_impedance, flwi);
+    ++provided_options;
+  }
+
+  if (argc != 2 * provided_options + 3) {
+    std::cerr << "Invalid command line arguments." << std::endl << help_message << std::endl;
+    return 1;
   }
 
   flwi.init();

--- a/source/franka_lightweight_interface/src/main.cpp
+++ b/source/franka_lightweight_interface/src/main.cpp
@@ -6,24 +6,23 @@ using namespace frankalwi;
 
 static void set_joint_damping(const std::string& level, FrankaLightWeightInterface& flwi) {
   if (level == "off") {
-    flwi.set_damping_gains(Eigen::Array<double, 7, 1>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0});
+    flwi.set_joint_damping(Eigen::Array<double, 7, 1>::Zero());
   } else if (level == "low") {
-    flwi.set_damping_gains(Eigen::Array<double, 7, 1>{1.0, 1.0, 0.9, 0.9, 0.8, 0.7, 0.6});
+    flwi.set_joint_damping(Eigen::Array<double, 7, 1>{1.0, 1.0, 0.9, 0.9, 0.8, 0.7, 0.6});
   } else if (level == "medium") {
-    flwi.set_damping_gains(Eigen::Array<double, 7, 1>{5.0, 5.0, 4.5, 4.5, 4.0, 3.5, 3.0});
+    flwi.set_joint_damping(Eigen::Array<double, 7, 1>{5.0, 5.0, 4.5, 4.5, 4.0, 3.5, 3.0});
   } else if (level == "high") {
-    flwi.set_damping_gains(Eigen::Array<double, 7, 1>{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0});
+    flwi.set_joint_damping(Eigen::Array<double, 7, 1>{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0});
   }
 }
 
 static void set_joint_impedance(const std::string& level, FrankaLightWeightInterface& flwi) {
-  // TODO find three different levels
   if (level == "low") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{400, 400, 400, 300, 300, 200, 200});
+    flwi.set_joint_impedance(Eigen::Array<double, 7, 1>{400, 400, 400, 300, 300, 200, 200});
   } else if (level == "medium") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{2000, 2000, 2000, 1500, 1500, 1000, 1000});
+    flwi.set_joint_impedance(Eigen::Array<double, 7, 1>{2000, 2000, 2000, 1500, 1500, 1000, 1000});
   } else if (level == "high") {
-    flwi.set_impedance(Eigen::Array<double, 7, 1>{4000, 4000, 4000, 3000, 3000, 2000, 2000});
+    flwi.set_joint_impedance(Eigen::Array<double, 7, 1>{4000, 4000, 4000, 3000, 3000, 2000, 2000});
   }
 }
 
@@ -66,7 +65,8 @@ int main(int argc, char** argv) {
   setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
   std::string help_message = "Usage: franka_lightweight_interface robot-id prefix ";
-  help_message += "[--damping <high|medium|low|off>] [--sensitivity <high|medium|low>]";
+  help_message += "[--joint-damping <high|medium|low|off>] [--sensitivity <high|medium|low>] "
+                  "[--joint-impedance <high|medium|low>]";
   std::string robot_ip = "172.16.0.2";
   std::string state_uri = "0.0.0.0:1601";
   std::string command_uri = "0.0.0.0:1602";
@@ -92,11 +92,11 @@ int main(int argc, char** argv) {
 
   FrankaLightWeightInterface flwi(robot_ip, state_uri, command_uri, prefix);
 
-  char* option = parse_option(argv, argv + argc, "--damping");
+  char* option = parse_option(argv, argv + argc, "--joint-damping");
   if (option) {
     std::string joint_damping = std::string(option);
     if (joint_damping != "off" && joint_damping != "low" && joint_damping != "medium" && joint_damping != "high") {
-      std::cerr << "Provide one of (off, low, medium, high) for option --damping" << std::endl << help_message
+      std::cerr << "Provide one of (off, low, medium, high) for option --joint-damping" << std::endl << help_message
                 << std::endl;
       return 1;
     }


### PR DESCRIPTION
I'm adding here the joint velocity control mode for the lightweight interface, such that when a `control_type_t::VELOCITY` is received from the network, it will start the joint velocity control. I also added low, medium and high joint impedance arrays that I found while playing around with the values.

There is no urgency merging this PR right away, it's mainly to make @AlbericDeLajarte aware of this branch.